### PR TITLE
Customise attribute the tooltip is bound to

### DIFF
--- a/src/_tooltip.scss
+++ b/src/_tooltip.scss
@@ -14,7 +14,7 @@
       var(--cooltipz-border-color, #{$cooltipz-border-color});
     box-shadow: 0 0 0.1875rem $cooltipz-shadow-color;
     color: var(--cooltipz-text-color, #{$cooltipz-text-color});
-    content: attr(aria-label);
+    content: attr(#{$cooltipz-attribute});
     font-family: Verdana, Geneva, Tahoma, var(--cooltipz-fontawesome, Arial), sans-serif;
     font-size: var(--cooltipz-font-size, #{$cooltipz-font-size});
     -webkit-font-smoothing: antialiased;

--- a/src/cooltipz.scss
+++ b/src/cooltipz.scss
@@ -1,5 +1,6 @@
 /*! Cooltipz.css v2.0.0 | MIT License | github.com/jackdomleo7/Cooltipz.css */
 
+@use "./variables/scss" as *;
 @use "./variables/css" as *;
 @use "./tooltip" as *;
 @use "./animations" as *;
@@ -12,7 +13,7 @@
 ::after = tooltip box and content
 */
 
-[aria-label] { // Required
+[#{$cooltipz-attribute}] { // Required
   &[data-cooltipz-dir], // Required
   &[class*="cooltipz"] { // Required
     // Default

--- a/src/cooltipz.scss
+++ b/src/cooltipz.scss
@@ -1,5 +1,6 @@
 /*! Cooltipz.css v2.0.0 | MIT License | github.com/jackdomleo7/Cooltipz.css */
 
+@forward "./variables/scss";
 @use "./variables/scss" as *;
 @use "./variables/css" as *;
 @use "./tooltip" as *;

--- a/src/variables/_scss.scss
+++ b/src/variables/_scss.scss
@@ -14,4 +14,5 @@ $cooltipz-large: 18.75rem !default;
 $cooltipz-arrow-size: 0.3125rem !default;
 $cooltipz-delay-show: 0s !default;
 $cooltipz-delay-hide: 0s !default;
+$cooltipz-attribute: "aria-label" !default;
 $cooltipz-shadow-color: rgb(0 0 0 / 30%);


### PR DESCRIPTION
## Enhancement/maintenance description
<!--
  Clearly and concisely describe the enhancement or maintenance.
  Link to an existing issue if one exists.
  Provide any screenshots if applicable.
-->
- Added customisable option to change the attribute the tooltip is bound to
- Fix overriding Sass variables
- Resolves #63 
- Resolves #66 

## Why is this enhancement/maintenance important?
<!--
  Explain why this enhancement or maintenance is important to have in Cooltipz.css.
  Provide any relevant links to back up your changes.
  If this pull request resolves a `project enhancement` issue, you can leave this section out and just put "This is described in the linked issue."
-->
- Some developers don't want to bind the tooltips to the `aria-label` attribute, so this gives them the option to change it
- Resolves a bug in v2.x where Sass variables cannot actually be overridden

### Did you test on all major browsers?
<!--
  Put an `x` in all the boxes that apply.
  If not, please add a brief explanation as to why you couldn't (e.g. "I couldn't test Safari because I don't have access to an Apple device").
-->
I couldn't test Safari because I don't have access to an Apple device.
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

## Other details
<!--
  Please add any other details we should be aware of below that don't fit in any of the categories above (e.g. "I would like this pull request to contribute towards my Hacktoberfest contributions").
  If you have nothing to add here, put "N/A".
-->
N/A

---

## T&Cs
<!--
  Put an `x` in all the boxes that you agree to.
-->

- [x] I confirm I have read and understand the [contributing guidelines](../../CONTRIBUTING.md)
- [x] I understand the work in this pull request will not be released straight away and will appear in a future release (if approved)
- [x] I confirm the work in this pull request is true and valid to the best of my knowledge